### PR TITLE
Separate SpinningBox component and add tests

### DIFF
--- a/apps/web/__tests__/spinning-box.test.tsx
+++ b/apps/web/__tests__/spinning-box.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { Canvas } from '@react-three/fiber'
+import SpinningBox from '../app/SpinningBox'
+
+test('renders canvas with spinning box', () => {
+  if (!(globalThis as any).ResizeObserver) {
+    const Polyfill = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(globalThis as any).ResizeObserver = Polyfill
+    if ((globalThis as any).window) {
+      ;(globalThis as any).window.ResizeObserver = Polyfill
+    }
+  }
+  const { container } = render(
+    <Canvas>
+      <SpinningBox />
+    </Canvas>
+  )
+  expect(container.querySelector('canvas')).toBeTruthy()
+})

--- a/apps/web/app/SpinningBox.tsx
+++ b/apps/web/app/SpinningBox.tsx
@@ -1,10 +1,10 @@
 'use client'
 import { useFrame } from '@react-three/fiber'
-import * as THREE from 'three'
+import type { Mesh } from 'three'
 import { useRef } from 'react'
 
 const SpinningBox = () => {
-  const ref = useRef<THREE.Mesh>(null!)
+  const ref = useRef<Mesh>(null!)
   useFrame(() => {
     if (ref.current) {
       ref.current.rotation.x += 0.01

--- a/apps/web/app/SpinningBox.tsx
+++ b/apps/web/app/SpinningBox.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import { useRef } from 'react'
+
+const SpinningBox = () => {
+  const ref = useRef<THREE.Mesh>(null!)
+  useFrame(() => {
+    if (ref.current) {
+      ref.current.rotation.x += 0.01
+      ref.current.rotation.y += 0.01
+    }
+  })
+  return (
+    <mesh ref={ref} data-testid='spinning-box'>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshNormalMaterial />
+    </mesh>
+  )
+}
+
+export default SpinningBox

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,23 +1,6 @@
 'use client'
-import { Canvas, useFrame } from '@react-three/fiber'
-import * as THREE from 'three'
-import { useRef } from 'react'
-
-const SpinningBox = () => {
-  const ref = useRef<THREE.Mesh>(null!)
-  useFrame(() => {
-    if (ref.current) {
-      ref.current.rotation.x += 0.01
-      ref.current.rotation.y += 0.01
-    }
-  })
-  return (
-    <mesh ref={ref}>
-      <boxGeometry args={[1, 1, 1]} />
-      <meshNormalMaterial />
-    </mesh>
-  )
-}
+import { Canvas } from '@react-three/fiber'
+import SpinningBox from './SpinningBox'
 
 const Home = () => {
   return (

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,3 +12,13 @@ for (const key of Object.getOwnPropertyNames(dom.window)) {
     ;(globalThis as any)[key] = (dom.window as any)[key]
   }
 }
+
+if (!(globalThis as any).ResizeObserver) {
+  const Polyfill = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  ;(globalThis as any).ResizeObserver = Polyfill
+  ;(globalThis as any).window.ResizeObserver = Polyfill
+}


### PR DESCRIPTION
## Summary
- factor out `<SpinningBox />` into its own file
- update page to import the new component
- polyfill `ResizeObserver` for DOM-based tests
- add a unit test verifying `<SpinningBox />` renders inside a canvas

## Testing
- `bun test --preload ./test/setup.ts`

------
https://chatgpt.com/codex/tasks/task_b_6870f5cc9eb08320a917242de3722b25