### PR TITLE
Add Dockerfile for Next.js app

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,16 @@
+# Install dependencies and build the app
+FROM oven/bun:1.2.14 AS BUILD
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --production=false
+COPY . .
+RUN bun run build
+
+# Production image with only production dependencies
+FROM oven/bun:1.2.14 AS RUNNER
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --production
+COPY --from=BUILD /app/.next .next
+COPY --from=BUILD /app/public public
+CMD ["bun", "run", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for `apps/web` that uses a build stage and a production stage

## Testing
- `bun run lint` *(fails: useWorkspaces removed)*
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_6871051962fc832094ea74b6679fe686