### PR TITLE
Add Perseverance promo page

### DIFF
--- a/apps/web/__tests__/perseverance-page.test.tsx
+++ b/apps/web/__tests__/perseverance-page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import PerseverancePromo from '../app/promos/perseverance/page'
 
-test('renders Hello world text', () => {
+test('renders Hello, world! text', () => {
   render(<PerseverancePromo />)
   expect(screen.getByText('Hello, world!')).toBeTruthy()
 })

--- a/apps/web/__tests__/perseverance-page.test.tsx
+++ b/apps/web/__tests__/perseverance-page.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import PerseverancePromo from '../app/promos/perseverance/page'
+
+test('renders Hello world text', () => {
+  render(<PerseverancePromo />)
+  expect(screen.getByText('Hello, world!')).toBeTruthy()
+})

--- a/apps/web/app/promos/perseverance/page.tsx
+++ b/apps/web/app/promos/perseverance/page.tsx
@@ -1,0 +1,7 @@
+export const dynamic = 'force-static'
+
+const PerseverancePromo = () => {
+  return <div>Hello, world!</div>
+}
+
+export default PerseverancePromo


### PR DESCRIPTION
## Summary
- add static promo page at `/promos/perseverance`
- test that the page renders

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_687262cd35688320940c8ae4e5f4c178