### PR TITLE
Switch web font to Noto Sans

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -23,7 +23,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-noto-sans), sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,16 +1,13 @@
 import { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Noto_Sans } from 'next/font/google'
 import './globals.css'
 import React from 'react'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin']
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin']
+const notoSans = Noto_Sans({
+  variable: '--font-noto-sans',
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  style: ['normal', 'italic']
 })
 
 export const metadata: Metadata = {
@@ -25,9 +22,7 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang='en'>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
-      </body>
+      <body className={notoSans.variable}>{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- use Noto Sans from `next/font/google` in the Next.js layout
- update global styles so `body` uses Noto Sans

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_68726c1e59048320bfa6df8a2eb1da67