### PR TITLE
Add PORT env support for Next.js Docker image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,4 +13,6 @@ COPY package.json bun.lock ./
 RUN bun install --production
 COPY --from=BUILD /app/.next .next
 COPY --from=BUILD /app/public public
+ENV PORT=3000
+EXPOSE 3000
 CMD ["bun", "run", "start"]


### PR DESCRIPTION
## Summary
- allow customizing the listening port of the web app
- expose port 3000 by default

## Testing
- `bun run test`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68726f81d64083209759cded2149092d