### PR TITLE
Add GLB loader component to Next.js app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,4 +45,9 @@ Please keep this documentation organized by categories (UI components, API inter
 ### Known Issues
 
 <!-- Add documented issues below this line following the example format -->
-<!-- No current issues -->
+### Issue: jest.mock unsupported with bun test
+- **Location**: apps/web/__tests__/glb-model.test.tsx
+- **Context**: Trying to mock "@react-three/drei" using jest.mock
+- **Problem**: bun's test environment does not implement jest.mock
+- **Solution**: Use `mock.module` from `bun:test` and import modules after setting the mock
+- **Prevention**: Prefer `mock.module` for module mocking in bun tests

--- a/apps/web/__tests__/glb-model.test.tsx
+++ b/apps/web/__tests__/glb-model.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { Canvas } from '@react-three/fiber'
+import { mock, jest, test, expect } from 'bun:test'
+import { Group } from 'three'
+
+mock.module('@react-three/drei', () => ({
+  useGLTF: jest.fn(() => ({ scene: new Group() }))
+}))
+
+test('renders canvas with GLB model', async () => {
+  const { default: GlbModel } = await import('../app/GlbModel')
+
+  const { container } = render(
+    <Canvas>
+      <GlbModel url='/3d-models/rover/rover-body.glb' />
+    </Canvas>
+  )
+
+  expect(container.querySelector('canvas')).toBeTruthy()
+})

--- a/apps/web/app/GlbModel.tsx
+++ b/apps/web/app/GlbModel.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useGLTF } from '@react-three/drei'
+import { Group } from 'three'
+
+interface GlbModelProps {
+  /**
+   * Path to the .glb file relative to the public directory
+   */
+  url: string
+}
+
+const GlbModel = ({ url }: GlbModelProps) => {
+  const { scene } = useGLTF(url)
+  return <primitive object={scene as Group} />
+}
+
+export default GlbModel


### PR DESCRIPTION
## Summary
- add `GlbModel` component for loading `.glb` files with `useGLTF`

## Testing
- `bun run lint`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6872ed0ff31083208a48728cd03eb16e