### PR TITLE
Update GlbModel to use group container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Run `bun install` at the repository root to install dependencies.
 - **Tests**: execute `bun run test` to run the test suite. The command preloads `test/setup.ts`.
 - **Linting**: execute `bun run lint` for lint checks.
 - Husky hooks automatically run tests and lint-staged on commit.
+- When adding or updating server or client code in the Next.js project (`apps/web`), add or update corresponding unit tests.
 
 Always ensure tests pass before committing changes.
 

--- a/apps/web/__tests__/glb-model.test.tsx
+++ b/apps/web/__tests__/glb-model.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 import { Canvas } from '@react-three/fiber'
+// bun:test exposes a Jest-like API so jest.fn can be used here
 import { mock, jest, test, expect } from 'bun:test'
 import { Group } from 'three'
 

--- a/apps/web/__tests__/glb-model.test.tsx
+++ b/apps/web/__tests__/glb-model.test.tsx
@@ -1,13 +1,12 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 import { Canvas } from '@react-three/fiber'
-// bun:test exposes a Jest-like API so jest.fn can be used here
-import { mock, jest, test, expect } from 'bun:test'
+import { mock, test, expect } from 'bun:test'
 import { Group } from 'three'
 
-mock.module('@react-three/drei', () => ({
-  useGLTF: jest.fn(() => ({ scene: new Group() }))
-}))
+mock('@react-three/drei', {
+  useGLTF: () => ({ scene: new Group() })
+})
 
 test('renders canvas with GLB model', async () => {
   const { default: GlbModel } = await import('../app/GlbModel')

--- a/apps/web/__tests__/glb-model.test.tsx
+++ b/apps/web/__tests__/glb-model.test.tsx
@@ -13,7 +13,11 @@ test('renders canvas with GLB model', async () => {
 
   const { container } = render(
     <Canvas>
-      <GlbModel url='/3d-models/rover/rover-body.glb' />
+      <GlbModel
+        url='/3d-models/rover/rover-body.glb'
+        position={[1, 2, 3]}
+        scale={2}
+      />
     </Canvas>
   )
 

--- a/apps/web/app/GlbModel.tsx
+++ b/apps/web/app/GlbModel.tsx
@@ -7,11 +7,23 @@ interface GlbModelProps {
    * Path to the .glb file relative to the public directory
    */
   url: string
+  /**
+   * Position of the model in the scene
+   */
+  position?: [number, number, number]
+  /**
+   * Uniform scale factor for the model
+   */
+  scale?: number
 }
 
-const GlbModel = ({ url }: GlbModelProps) => {
+const GlbModel = ({ url, position = [0, 0, 0], scale = 1 }: GlbModelProps) => {
   const { scene } = useGLTF(url)
-  return <primitive object={scene as Group} />
+  return (
+    <group position={position} scale={scale}>
+      <primitive object={scene as Group} />
+    </group>
+  )
 }
 
 export default GlbModel


### PR DESCRIPTION
## Summary
- wrap `GlbModel` output in a `<group>` element
- accept optional `position` and `scale` props for `GlbModel`
- exercise new props in `glb-model.test`

## Testing
- `bun run lint`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6872f37e1f5c83208a31c61b009cbcf8