### PR TITLE
Add canvas and GLB props

### DIFF
--- a/apps/web/__tests__/app/promos/perseverance/page.test.tsx
+++ b/apps/web/__tests__/app/promos/perseverance/page.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { PerseverancePromo } from '@/promos/perseverance/page'
 
-test('renders Hello, world! text', () => {
-  render(<PerseverancePromo />)
+test('renders promo canvas', () => {
+  const { container } = render(<PerseverancePromo />)
   expect(screen.getByTestId('rover-explorer')).toBeInTheDocument()
+  expect(container.querySelector('canvas')).toBeTruthy()
 })

--- a/apps/web/app/GlbModel.tsx
+++ b/apps/web/app/GlbModel.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useGLTF } from '@react-three/drei'
-import { Group } from 'three'
+import { Group, Object3D } from 'three'
+import { useEffect } from 'react'
 
 interface GlbModelProps {
   /**
@@ -15,10 +16,43 @@ interface GlbModelProps {
    * Uniform scale factor for the model
    */
   scale?: number
+  /**
+   * Enable or disable shadow casting for all meshes in the model
+   */
+  castShadow?: boolean
+  /**
+   * Called after the model successfully loads
+   */
+  onLoad?: () => void
+  /**
+   * Called if an error occurs while loading the model
+   */
+  onError?: (error: unknown) => void
 }
 
-const GlbModel = ({ url, position = [0, 0, 0], scale = 1 }: GlbModelProps) => {
-  const { scene } = useGLTF(url)
+const GlbModel = ({
+  url,
+  position = [0, 0, 0],
+  scale = 1,
+  castShadow = false,
+  onLoad,
+  onError
+}: GlbModelProps) => {
+  let scene: Group
+  try {
+    ;({ scene } = useGLTF(url))
+  } catch (err) {
+    onError?.(err)
+    throw err
+  }
+
+  useEffect(() => {
+    scene.traverse(obj => {
+      ;(obj as Object3D).castShadow = castShadow
+    })
+    onLoad?.()
+  }, [scene, castShadow, onLoad])
+
   return (
     <group position={position} scale={scale}>
       <primitive object={scene as Group} />

--- a/apps/web/app/promos/perseverance/page.tsx
+++ b/apps/web/app/promos/perseverance/page.tsx
@@ -1,4 +1,8 @@
+'use client'
 export const dynamic = 'force-static'
+import { Canvas } from '@react-three/fiber'
+import { Suspense } from 'react'
+import GlbModel from '@/app/GlbModel'
 
 export const PerseverancePromo = () => (
   <div
@@ -11,7 +15,15 @@ export const PerseverancePromo = () => (
       id={'rover-explorer'}
       className='flex justify-center bg-size-[400px] w-full max-w-full'
     >
-      Hello, world!
+      <Canvas camera={{ fov: 20 }} style={{ width: '400px', height: '400px' }}>
+        <ambientLight />
+        <Suspense fallback={null}>
+          <GlbModel
+            url='https://gs-strapi.s3.us-east-1.amazonaws.com/rover_body_44b8019c95.glb'
+            castShadow
+          />
+        </Suspense>
+      </Canvas>
     </div>
   </div>
 )


### PR DESCRIPTION
## Summary
- allow shadow casting and callbacks for `GlbModel`
- render rover model on the Perseverance promo page using a canvas
- update promo test for canvas

## Testing
- `bun run lint`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_687317e8c75c83209bc96ba8d298b37e