### PR TITLE
Fix failing promo test

### DIFF
--- a/apps/web/__tests__/app/promos/perseverance/page.test.tsx
+++ b/apps/web/__tests__/app/promos/perseverance/page.test.tsx
@@ -1,8 +1,25 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import { PerseverancePromo } from '@/promos/perseverance/page'
+import { mock, test, expect } from 'bun:test'
 
-test('renders promo canvas', () => {
+test('renders promo canvas', async () => {
+  mock.module('@react-three/drei', () => ({
+    Stars: () => null,
+    SpotLight: () => null,
+    useGLTF: () => ({ scene: new (require('three').Group)() })
+  }))
+  mock.module('@react-three/postprocessing', () => ({
+    EffectComposer: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    Bloom: () => null
+  }))
+  mock.module('@react-three/drei/core/Sky', () => ({
+    Sky: () => null
+  }))
+  const { PerseverancePromo } = await import(
+    '../../../../app/promos/perseverance/page?test=' + Math.random()
+  )
   const { container } = render(<PerseverancePromo />)
   expect(screen.getByTestId('rover-explorer')).toBeInTheDocument()
   expect(container.querySelector('canvas')).toBeTruthy()

--- a/apps/web/__tests__/app/promos/perseverance/page.test.tsx
+++ b/apps/web/__tests__/app/promos/perseverance/page.test.tsx
@@ -17,6 +17,9 @@ test('renders promo canvas', async () => {
   mock.module('@react-three/drei/core/Sky', () => ({
     Sky: () => null
   }))
+  mock.module('@react-three/drei/core/Stars', () => ({
+    Stars: () => null
+  }))
   const { PerseverancePromo } = await import(
     '../../../../app/promos/perseverance/page?test=' + Math.random()
   )

--- a/apps/web/app/GlbModel.tsx
+++ b/apps/web/app/GlbModel.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useGLTF } from '@react-three/drei'
-import { Group, Object3D } from 'three'
+import { Group, Object3D, Material } from 'three'
 import { useLayoutEffect } from 'react'
 import React from 'react'
 
@@ -149,11 +149,13 @@ const GlbModelInner = ({
       ;(obj as Object3D).receiveShadow = receiveShadow
 
       // Apply opacity if provided and the object has a material
-      const object = obj as any
+      const object = obj as Object3D & {
+        material?: Material | Material[]
+      }
       if (object.material && opacity !== 1.0) {
         // If a material is an array, handle each material
         if (Array.isArray(object.material)) {
-          object.material.forEach((mat: any) => {
+          object.material.forEach((mat: Material) => {
             mat.transparent = opacity < 1.0
             mat.opacity = opacity
           })

--- a/apps/web/app/promos/perseverance/page.tsx
+++ b/apps/web/app/promos/perseverance/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Stars, SpotLight } from '@react-three/drei'
+import { Stars } from '@react-three/drei/core/Stars'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { Canvas } from '@react-three/fiber'
 import { Suspense } from 'react'

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
       "dependencies": {
         "@react-three/drei": "^10.5.0",
         "@react-three/fiber": "^9.2.0",
+        "@react-three/postprocessing": "^3.0.4",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "immer": "^10.1.1",
         "next": "15.3.5",
@@ -292,6 +293,8 @@
     "@react-three/drei": ["@react-three/drei@10.5.0", "", { "dependencies": { "@babel/runtime": "^7.26.0", "@mediapipe/tasks-vision": "0.10.17", "@monogrid/gainmap-js": "^3.0.6", "@use-gesture/react": "^10.3.1", "camera-controls": "^3.0.0", "cross-env": "^7.0.3", "detect-gpu": "^5.0.56", "glsl-noise": "^0.0.0", "hls.js": "^1.5.17", "maath": "^0.10.8", "meshline": "^3.3.1", "stats-gl": "^2.2.8", "stats.js": "^0.17.0", "suspend-react": "^0.1.3", "three-mesh-bvh": "^0.8.3", "three-stdlib": "^2.35.6", "troika-three-text": "^0.52.4", "tunnel-rat": "^0.1.2", "use-sync-external-store": "^1.4.0", "utility-types": "^3.11.0", "zustand": "^5.0.1" }, "peerDependencies": { "@react-three/fiber": "^9.0.0", "react": "^19", "react-dom": "^19", "three": ">=0.159" }, "optionalPeers": ["react-dom"] }, "sha512-8VHFmwiIixw0MhTt8ZiLPZH/JrJVsRQiosHqBrV2qRKhYB4aPJ1A9MkqQdKnxUfvvbsi0zu2iXeRCH1HhUaNsg=="],
 
     "@react-three/fiber": ["@react-three/fiber@9.2.0", "", { "dependencies": { "@babel/runtime": "^7.17.8", "@types/react-reconciler": "^0.28.9", "@types/webxr": "*", "base64-js": "^1.5.1", "buffer": "^6.0.3", "its-fine": "^2.0.0", "react-reconciler": "^0.31.0", "react-use-measure": "^2.1.7", "scheduler": "^0.25.0", "suspend-react": "^0.1.3", "use-sync-external-store": "^1.4.0", "zustand": "^5.0.3" }, "peerDependencies": { "expo": ">=43.0", "expo-asset": ">=8.4", "expo-file-system": ">=11.0", "expo-gl": ">=11.0", "react": "^19.0.0", "react-dom": "^19.0.0", "react-native": ">=0.78", "three": ">=0.156" }, "optionalPeers": ["expo", "expo-asset", "expo-file-system", "expo-gl", "react-dom", "react-native"] }, "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ=="],
+
+    "@react-three/postprocessing": ["@react-three/postprocessing@3.0.4", "", { "dependencies": { "maath": "^0.6.0", "n8ao": "^1.9.4", "postprocessing": "^6.36.6" }, "peerDependencies": { "@react-three/fiber": "^9.0.0", "react": "^19.0", "three": ">= 0.156.0" } }, "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -1267,6 +1270,8 @@
 
     "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
+    "n8ao": ["n8ao@1.10.1", "", { "peerDependencies": { "postprocessing": ">=6.30.0", "three": ">=0.137" } }, "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w=="],
+
     "nano-spawn": ["nano-spawn@1.0.2", "", {}, "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1410,6 +1415,8 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postprocessing": ["postprocessing@6.37.6", "", { "peerDependencies": { "three": ">= 0.157.0 < 0.179.0" } }, "sha512-KrdKLf1257RkoIk3z3nhRS0aToKrX2xJgtR0lbnOQUjd+1I4GVNv1gQYsQlfRglvEXjpzrwqOA5fXfoDBimadg=="],
 
     "potpack": ["potpack@1.0.2", "", {}, "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="],
 
@@ -1848,6 +1855,8 @@
     "@npmcli/map-workspaces/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@nx/devkit/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
+
+    "@react-three/postprocessing/maath": ["maath@0.6.0", "", { "peerDependencies": { "@types/three": ">=0.144.0", "three": ">=0.144.0" } }, "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw=="],
 
     "@tailwindcss/oxide/tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
 


### PR DESCRIPTION
## Summary
- mock Drei and postprocessing modules in perseverance promo test
- avoid Drei root export by importing `Stars` directly
- clean up types in GlbModel

## Testing
- `bun run test`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_6873b61ba7148320b395cf4248f8371f