### PR TITLE
Add build step to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,5 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install
       - run: bun run test
+      - run: bun run build
+      - run: bun run --cwd apps/web build


### PR DESCRIPTION
## Summary
- run production builds in the GitHub Actions test workflow

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`
- `bun run build`
- `bun run --cwd apps/web build` *(fails: Failed to fetch `Noto Sans` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_687417b2f1488320a43c68cc5a80a2b1