### PR TITLE
Fix ES5 output for packages

### DIFF
--- a/packages/glb-model/rollup.config.js
+++ b/packages/glb-model/rollup.config.js
@@ -19,5 +19,9 @@ export default {
     }
   ],
   external: id => !id.startsWith('.') && !path.isAbsolute(id),
-  plugins: [typescript(), nodeResolve(), commonjs()]
+  plugins: [
+    typescript({ outputToFilesystem: false }),
+    nodeResolve(),
+    commonjs()
+  ]
 }

--- a/packages/glb-model/tsconfig.json
+++ b/packages/glb-model/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "target": "ES5",
     "declaration": true,
     "declarationDir": "dist",
     "jsx": "react-jsx"

--- a/packages/lerna-v2-utils/rollup.config.js
+++ b/packages/lerna-v2-utils/rollup.config.js
@@ -9,5 +9,5 @@ export default {
       sourcemap: true
     }
   ],
-  plugins: [typescript()]
+  plugins: [typescript({ outputToFilesystem: false })]
 }

--- a/packages/lerna-v2-utils/tsconfig.json
+++ b/packages/lerna-v2-utils/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "target": "ES5",
     "declaration": true,
     "declarationDir": "dist"
   },


### PR DESCRIPTION
## Summary
- compile shared packages down to ES5
- disable filesystem output in rollup to silence warning

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_6874701be06483209ea6e80a8f250544