### PR TITLE
Update Next.js Dockerfile for workspace packages

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,11 +1,17 @@
-# Install dependencies and build the app
+# Install dependencies and build the Next.js app
 ARG PORT=3000
 FROM oven/bun:1.2.14 AS BUILD
 WORKDIR /app
+
+# Copy workspace files and packages from the monorepo root
 COPY package.json bun.lock ./
+COPY packages ./packages
+COPY types ./types
+COPY apps/web ./apps/web
+
+# Install all workspace dependencies and build the application
 RUN bun install --production=false
-COPY . .
-RUN bun run build
+RUN bun run --cwd apps/web build
 
 # Production image with only production dependencies
 FROM oven/bun:1.2.14 AS RUNNER
@@ -13,8 +19,8 @@ ARG PORT
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --production
-COPY --from=BUILD /app/.next .next
-COPY --from=BUILD /app/public public
+COPY --from=BUILD /app/apps/web/.next .next
+COPY --from=BUILD /app/apps/web/public public
 ENV PORT=${PORT}
 EXPOSE ${PORT}
 CMD ["bun", "run", "start"]


### PR DESCRIPTION
## Summary
- update Next.js Dockerfile to copy packages and types from repo root
- adjust build commands and paths to work from monorepo context

## Testing
- `bun run test`
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687487d99f1883209e2e091f1c8508df