### PR TITLE
chore(glb-model): mark package as unlicensed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,9 @@
     "packages/glb-model": {
       "name": "@geocaching/glb-model",
       "version": "0.1.0",
+      "devDependencies": {
+        "@geocaching/lerna-v2-utils": "*",
+      },
       "peerDependencies": {
         "@react-three/drei": "^10.5.0",
         "@react-three/fiber": "^9.2.0",

--- a/packages/glb-model/LICENSE.md
+++ b/packages/glb-model/LICENSE.md
@@ -1,0 +1,3 @@
+UNLICENSED
+
+This project is not licensed for external use. All rights reserved.

--- a/packages/glb-model/package.json
+++ b/packages/glb-model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@geocaching/glb-model",
   "version": "0.1.0",
+  "license": "UNLICENSED",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- mark the `@geocaching/glb-model` package as `UNLICENSED`
- add a `LICENSE.md` file for the package

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_b_6874f287f0d483208228bdac13636636