### PR TITLE
Add publish dry run workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,0 +1,30 @@
+name: Publish Dry Run
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+      - run: bun install
+      - id: detect_changes
+        run: |
+          CHANGED=$(bun x lerna changed --json --loglevel silent || echo "[]")
+          COUNT=$(echo "$CHANGED" | jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+      - name: Publish dry run
+        if: steps.detect_changes.outputs.count != '0'
+        env:
+          NPM_CONFIG_DRY_RUN: 'true'
+        run: bun x lerna publish from-package --yes --no-private --loglevel info


### PR DESCRIPTION
## Summary
- add a new workflow to detect changed packages on `main`
- if changes are found, run a dry-run publish via lerna

## Testing
- `bun run test`
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6874f702dd1c832084ddb6fc25746185