### PR TITLE
Update publish dry run workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  publish:
+  publish_dry_run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +18,8 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - id: detect_changes
         run: |
           CHANGED=$(bun x lerna changed --json --loglevel silent || echo "[]")

--- a/packages/glb-model/package.json
+++ b/packages/glb-model/package.json
@@ -5,8 +5,12 @@
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "prepare": "bun run build"
   },
   "devDependencies": {
     "@geocaching/lerna-v2-utils": "*"


### PR DESCRIPTION
## Summary
- install `jq` in publish dry run workflow
- rename job id to `publish_dry_run`
- include build output via `files` and add `prepare` script for `glb-model`

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6874f962ccbc83208bdc5cc7b6b25b04