### PR TITLE
Add publish step after dry run

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -33,3 +33,8 @@ jobs:
         env:
           NPM_CONFIG_DRY_RUN: 'true'
         run: bun x lerna publish from-package --yes --no-private --loglevel info --ignore-scripts
+      - name: Publish packages
+        if: steps.detect_changes.outputs.count != '0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun x lerna publish from-package --yes --no-private --loglevel info --ignore-scripts


### PR DESCRIPTION
## Summary
- add a real publish step that runs when the dry run succeeded

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_68752227fe4c8320b5a14bde8094154b