### PR TITLE
Add restricted access when publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,8 @@
   "command": {
     "publish": {
       "conventionalCommits": true,
-      "message": "ci: publish"
+      "message": "ci: publish",
+      "access": "restricted"
     },
     "version": {
       "conventionalCommits": true,


### PR DESCRIPTION
## Summary
- ensure lerna publish uses private access level

## Testing
- `bun run test`
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687529eebda8832082e9d9a05a791df3