### PR TITLE
Set registry in publish workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -37,4 +37,5 @@ jobs:
         if: ${{ steps.detect_changes.outputs.count != '0' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: bun x lerna publish from-package --yes --no-private --loglevel info --ignore-scripts


### PR DESCRIPTION
## Summary
- ensure the npm registry is explicitly defined in the publish step

## Testing
- `bun run test`
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6876b410d3f08320828de52442534b17