### PR TITLE
Add registry flag to workflow publish step

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-        run: bun x lerna publish from-package --yes --no-private --loglevel info --ignore-scripts
+        run: bun x lerna publish from-package --yes --no-private --loglevel info --ignore-scripts --registry https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- update `publish-dry-run.yml` to pass `--registry` to the final publish command

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_6876b679b6908320a7666178342112ec