### PR TITLE
Fix CI test workflow

### DIFF
--- a/.github/workflows/lerna-changed.yml
+++ b/.github/workflows/lerna-changed.yml
@@ -39,8 +39,8 @@ jobs:
             exit 1
           fi
           # Determine whether any packages changed using jq for reliability
-          is_empty=$(echo "$changed" | jq 'length == 0')
-          echo "packages=$is_empty" >> "$GITHUB_OUTPUT"
+          has_changes=$(echo "$changed" | jq 'length == 0')
+          echo "packages=$has_changes" >> "$GITHUB_OUTPUT"
 
       - name: Dry run publish
         if: steps.changes.outputs.packages == 'false'

--- a/.github/workflows/lerna-changed.yml
+++ b/.github/workflows/lerna-changed.yml
@@ -21,7 +21,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install
       - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+        run: which jq || (sudo apt-get update && sudo apt-get install -y jq)
       - name: Check for changed packages
         id: changes
         run: |

--- a/.github/workflows/lerna-changed.yml
+++ b/.github/workflows/lerna-changed.yml
@@ -20,6 +20,8 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Check for changed packages
         id: changes
         run: |
@@ -36,7 +38,8 @@ jobs:
             cat error.log
             exit 1
           fi
-          is_empty=$(echo "$changed" | bun run --eval "console.log(JSON.parse(process.argv[1]).length === 0)" 2>/dev/null)
+          # Determine whether any packages changed using jq for reliability
+          is_empty=$(echo "$changed" | jq 'length == 0')
           echo "packages=$is_empty" >> "$GITHUB_OUTPUT"
 
       - name: Dry run publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- run the CI test workflow only for pull requests
- use `jq` to parse `lerna changed` output correctly
- ensure `jq` is installed before running `lerna changed`

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_687b102344548320997ab49f81bb572e