### PR TITLE
Configure npm registry, scope, and auth in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,14 @@ jobs:
           git reset --hard origin/main
           echo "Performed hard reset to ensure clean branch state"
 
-      - name: Set npm registry to official npm registry
+      - name: Configure npm for publish
         if: steps.changes.outputs.has_changes == 'true'
-        run: npm config set registry https://registry.npmjs.org/
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm set registry https://registry.npmjs.org/
+          npm set scope @geocaching
+          npm set //registry.npmjs.org/:_authToken $NPM_TOKEN
 
       - name: Dry run publish
         if: steps.changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary
- ensure publish workflow sets npm registry and auth

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687b7dec84588320bd159e0e4db3d2f9