### PR TITLE
Add publish step on dry-run success

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,4 +66,6 @@ jobs:
 
       - name: Publish packages
         if: steps.changes.outputs.has_changes == 'true' && steps.dry_run.outcome == 'success'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun x lerna publish from-package --yes --no-private --ignore-scripts --loglevel info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,12 @@ jobs:
           npm set //registry.npmjs.org/:_authToken $NPM_TOKEN
 
       - name: Dry run publish
+        id: dry_run
         if: steps.changes.outputs.has_changes == 'true'
         env:
           NPM_CONFIG_DRY_RUN: 'true'
         run: bun x lerna publish from-package --yes --no-private --loglevel info
+
+      - name: Publish packages
+        if: steps.changes.outputs.has_changes == 'true' && steps.dry_run.outcome == 'success'
+        run: bun x lerna publish from-package --yes --no-private --ignore-scripts --loglevel info


### PR DESCRIPTION
## Summary
- run actual lerna publish when the dry run succeeds

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687b843a7c38832097b91f3248fb1094