### PR TITLE
Fix lerna changed handling in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           latest_tag=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))
           echo "Latest tag: $latest_tag"
-          changed=$(bun x lerna changed --json 2>error.log)
+          changed=$(bun x lerna changed --json 2>error.log || true)
           if [ $? -eq 0 ]; then
             echo "$changed"
           elif grep -q "No changed packages found" error.log; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,9 @@ jobs:
         run: |
           latest_tag=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))
           echo "Latest tag: $latest_tag"
-          changed=$(bun x lerna changed --json 2>error.log || true)
-          if [ $? -eq 0 ]; then
+          changed=$(bun x lerna changed --json 2>error.log)
+          exit_code=$?
+          if [ $exit_code -eq 0 ]; then
             echo "$changed"
           elif grep -q "No changed packages found" error.log; then
             echo "[]"


### PR DESCRIPTION
## Summary
- prevent `lerna changed` non-zero exit from aborting workflow

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687ba2f88598832089c3d544d3e49dc5