### PR TITLE
Remove --ignore-scripts from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,4 +69,4 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true' && steps.dry_run.outcome == 'success'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun x lerna publish from-package --yes --no-private --ignore-scripts --loglevel info
+        run: bun x lerna publish from-package --yes --no-private --loglevel info


### PR DESCRIPTION
## Summary
- remove the `--ignore-scripts` flag so publish runs package lifecycle scripts

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687c555528c48320a7b2b25a96323923