### PR TITLE
Add custom material support to glb-model

### DIFF
--- a/apps/web/__tests__/glb-model.test.tsx
+++ b/apps/web/__tests__/glb-model.test.tsx
@@ -1,12 +1,24 @@
 jest.mock('@react-three/drei', () => {
   const React = require('react')
-  const { Group } = require('three')
+  const { Group, Mesh, BoxGeometry, MeshBasicMaterial } = require('three')
   const Html = jest.fn(({ children }: { children: React.ReactNode }) => (
     <div data-testid='html-wrapper'>{children}</div>
   ))
+  const scenes: any[] = []
   return {
-    useGLTF: () => ({ scene: new Group() }),
-    Html
+    useGLTF: () => {
+      const group = new Group()
+      const mesh = new Mesh(new BoxGeometry(), new MeshBasicMaterial())
+      group.add(mesh)
+      scenes.push(group)
+      return { scene: group }
+    },
+    Html,
+    shaderMaterial: jest.fn((...args) => {
+      const { shaderMaterial } = jest.requireActual('@react-three/drei')
+      return shaderMaterial(...args)
+    }),
+    __scenes: scenes
   }
 })
 
@@ -19,10 +31,12 @@ jest.mock('@react-three/fiber', () => {
   }
 })
 
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Canvas } from '@react-three/fiber'
 import GlbModel from '@geocaching/glb-model'
+import { RawShaderMaterial, MeshBasicMaterial } from 'three'
+import { shaderMaterial } from '@react-three/drei'
 
 test('renders canvas with GLB model', () => {
   const { container } = render(
@@ -55,4 +69,56 @@ test('renders provided html content', () => {
   const firstCall = (drei.Html as jest.Mock).mock.calls[0][0]
   expect(firstCall).toEqual(expect.objectContaining({ children: htmlElement }))
   expect(container.querySelector('[data-testid="html-node"]')).toBeTruthy()
+})
+
+test('applies provided MeshBasicMaterial', async () => {
+  const material = new MeshBasicMaterial()
+  const drei = require('@react-three/drei')
+  const { __scenes } = drei
+
+  render(
+    <Canvas>
+      <GlbModel url='/model.glb' material={material} />
+    </Canvas>
+  )
+
+  await waitFor(() => {
+    expect(__scenes[__scenes.length - 1].children[0].material).toBe(material)
+  })
+})
+
+test('applies shaderMaterial instance', async () => {
+  const CustomMat = shaderMaterial({}, 'void main(){}', 'void main(){}')
+  const material = new CustomMat()
+  const drei = require('@react-three/drei')
+  const { __scenes } = drei
+
+  render(
+    <Canvas>
+      <GlbModel url='/model.glb' material={material} />
+    </Canvas>
+  )
+
+  await waitFor(() => {
+    expect(__scenes[__scenes.length - 1].children[0].material).toBe(material)
+  })
+})
+
+test('applies RawShaderMaterial instance', async () => {
+  const material = new RawShaderMaterial({
+    vertexShader: 'void main(){}',
+    fragmentShader: 'void main(){}'
+  })
+  const drei = require('@react-three/drei')
+  const { __scenes } = drei
+
+  render(
+    <Canvas>
+      <GlbModel url='/model.glb' material={material} />
+    </Canvas>
+  )
+
+  await waitFor(() => {
+    expect(__scenes[__scenes.length - 1].children[0].material).toBe(material)
+  })
 })

--- a/packages/glb-model/CHANGELOG.md
+++ b/packages/glb-model/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/Geocaching/lerna-v2/compare/@geocaching/glb-model@0.2.1...@geocaching/glb-model@0.3.0) (2025-07-17)
+
+### Features
+
+- add support for custom materials including built-in shaders, `shaderMaterial`, and `RawShaderMaterial`
+
 ## [0.2.1](https://github.com/Geocaching/lerna-v2/compare/@geocaching/glb-model@0.2.0...@geocaching/glb-model@0.2.1) (2025-07-16)
 
 **Note:** Version bump only for package @geocaching/glb-model

--- a/packages/glb-model/README.md
+++ b/packages/glb-model/README.md
@@ -21,7 +21,36 @@ import GlbModel from '@geocaching/glb-model'
 export default function Example() {
   return (
     <Canvas>
-      <GlbModel url="/path/to/model.glb" />
+      <GlbModel url='/path/to/model.glb' />
+    </Canvas>
+  )
+}
+```
+
+You can pass any `THREE.Material` instance, including materials created with
+`shaderMaterial` from `@react-three/drei` or `RawShaderMaterial` from `three`:
+
+```tsx
+import { shaderMaterial } from '@react-three/drei'
+import { RawShaderMaterial, MeshBasicMaterial } from 'three'
+
+const HighlightMaterial = shaderMaterial(
+  {},
+  /* glsl */ `void main() { gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+  /* glsl */ `void main() { gl_FragColor = vec4(1.0,0.0,0.0,1.0); }`
+)
+
+export default function CustomExample() {
+  return (
+    <Canvas>
+      <GlbModel url='/path/to/model.glb' material={new MeshBasicMaterial()} />
+      <GlbModel url='/path/to/model.glb' material={new HighlightMaterial()} />
+      <GlbModel
+        url='/path/to/model.glb'
+        material={
+          new RawShaderMaterial({ vertexShader: '...', fragmentShader: '...' })
+        }
+      />
     </Canvas>
   )
 }
@@ -29,15 +58,16 @@ export default function Example() {
 
 ## Props
 
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `url` | `string` | – | Path to the `.glb` file relative to the public directory |
-| `position` | `[number, number, number]` | `[0, 0, 0]` | Position of the model in the scene |
-| `rotation` | `[number, number, number]` | `[0, 0, 0]` | Rotation of the model in radians |
-| `scale` | `number` | `1` | Uniform scale factor for the model |
-| `opacity` | `number` | `1.0` | Opacity of the model |
-| `castShadow` | `boolean` | `false` | Whether the model should cast shadows |
-| `receiveShadow` | `boolean` | `false` | Whether the model should receive shadows |
-| `onLoad` | `() => void` | – | Called after the model successfully loads |
-| `onError` | `(error: unknown) => void` | – | Called if an error occurs while loading |
-| `htmlContent` | `React.ReactNode` | – | Optional HTML content rendered inside the model |
+| Prop            | Type                       | Default     | Description                                                                                            |
+| --------------- | -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `url`           | `string`                   | –           | Path to the `.glb` file relative to the public directory                                               |
+| `position`      | `[number, number, number]` | `[0, 0, 0]` | Position of the model in the scene                                                                     |
+| `rotation`      | `[number, number, number]` | `[0, 0, 0]` | Rotation of the model in radians                                                                       |
+| `scale`         | `number`                   | `1`         | Uniform scale factor for the model                                                                     |
+| `opacity`       | `number`                   | `1.0`       | Opacity of the model                                                                                   |
+| `material`      | `THREE.Material`           | –           | Material applied to all meshes. Supports built-in materials, `shaderMaterial`, and `RawShaderMaterial` |
+| `castShadow`    | `boolean`                  | `false`     | Whether the model should cast shadows                                                                  |
+| `receiveShadow` | `boolean`                  | `false`     | Whether the model should receive shadows                                                               |
+| `onLoad`        | `() => void`               | –           | Called after the model successfully loads                                                              |
+| `onError`       | `(error: unknown) => void` | –           | Called if an error occurs while loading                                                                |
+| `htmlContent`   | `React.ReactNode`          | –           | Optional HTML content rendered inside the model                                                        |

--- a/packages/glb-model/package.json
+++ b/packages/glb-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geocaching/glb-model",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "UNLICENSED",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Summary
- allow setting a material when loading GLB models
- document custom material usage in glb-model README
- bump glb-model package version to 0.3.0 and update changelog
- test applying MeshBasicMaterial, shaderMaterial and RawShaderMaterial
- update jsdocs for new `material` prop

## Testing
- `bun run lint`
- `bun run test`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_687c56c981ac8320aabb572436ac59de