### PR TITLE
Relocate glb-model tests

### DIFF
--- a/packages/glb-model/__tests__/src/index.tsx
+++ b/packages/glb-model/__tests__/src/index.tsx
@@ -1,3 +1,10 @@
+import { render, waitFor } from '@testing-library/react'
+import * as React from 'react'
+import { Canvas } from '@react-three/fiber'
+import GlbModel from '@geocaching/glb-model'
+import { RawShaderMaterial, MeshBasicMaterial } from 'three'
+import { shaderMaterial } from '@react-three/drei'
+
 jest.mock('@react-three/drei', () => {
   const React = require('react')
   const { Group, Mesh, BoxGeometry, MeshBasicMaterial } = require('three')
@@ -30,13 +37,6 @@ jest.mock('@react-three/fiber', () => {
     )
   }
 })
-
-import { render, waitFor } from '@testing-library/react'
-import React from 'react'
-import { Canvas } from '@react-three/fiber'
-import GlbModel from '@geocaching/glb-model'
-import { RawShaderMaterial, MeshBasicMaterial } from 'three'
-import { shaderMaterial } from '@react-three/drei'
 
 test('renders canvas with GLB model', () => {
   const { container } = render(


### PR DESCRIPTION
## Summary
- move GLB model tests out of Next.js app

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_687e5fb5e338832094bcc2ad055e48ca