### PR TITLE
Add cartoon shader for GLB models

### DIFF
--- a/apps/web/__tests__/cartoon-model.test.tsx
+++ b/apps/web/__tests__/cartoon-model.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { Canvas } from '@react-three/fiber'
+import CartoonModel from '../app/CartoonModel'
+
+test('renders canvas with cartoon model', () => {
+  const { container } = render(
+    <Canvas>
+      <CartoonModel url='/3d-models/rover/rover-body.glb' />
+    </Canvas>
+  )
+  expect(container.querySelector('canvas')).toBeTruthy()
+})

--- a/apps/web/app/CartoonModel.tsx
+++ b/apps/web/app/CartoonModel.tsx
@@ -1,10 +1,21 @@
 'use client'
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import GlbModel from '@geocaching/glb-model'
 import CartoonMaterial from './CartoonShaderMaterial'
 
-const CartoonModel = ({ url, ...rest }: { url: string } & Omit<React.ComponentProps<typeof GlbModel>, 'url' | 'material'>) => {
+const CartoonModel = ({
+  url,
+  ...rest
+}: { url: string } & Omit<
+  React.ComponentProps<typeof GlbModel>,
+  'url' | 'material'
+>) => {
   const material = useMemo(() => new CartoonMaterial(), [])
+  useEffect(() => {
+    return () => {
+      material.dispose()
+    }
+  }, [material])
   return <GlbModel url={url} material={material} {...rest} />
 }
 

--- a/apps/web/app/CartoonModel.tsx
+++ b/apps/web/app/CartoonModel.tsx
@@ -1,0 +1,11 @@
+'use client'
+import React, { useMemo } from 'react'
+import GlbModel from '@geocaching/glb-model'
+import CartoonMaterial from './CartoonShaderMaterial'
+
+const CartoonModel = ({ url, ...rest }: { url: string } & Omit<React.ComponentProps<typeof GlbModel>, 'url' | 'material'>) => {
+  const material = useMemo(() => new CartoonMaterial(), [])
+  return <GlbModel url={url} material={material} {...rest} />
+}
+
+export default CartoonModel

--- a/apps/web/app/CartoonShaderMaterial.ts
+++ b/apps/web/app/CartoonShaderMaterial.ts
@@ -1,14 +1,48 @@
 import { shaderMaterial } from '@react-three/drei'
 import { Color, Vector3 } from 'three'
 
+const vertexShader = /* glsl */ `
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+
+  void main() {
+    vNormal = normalize(normalMatrix * normal);
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    vViewDir = -mvPosition.xyz;
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  uniform vec3 uColor;
+  uniform vec3 uLightDir;
+  uniform float uEdgeThreshold;
+
+  varying vec3 vNormal;
+  varying vec3 vViewDir;
+
+  void main() {
+    vec3 lightDir = normalize(uLightDir);
+    float diffuse = max(dot(vNormal, lightDir), 0.0);
+    float levels = 3.0;
+    float toon = floor(diffuse * levels) / levels;
+    vec3 base = uColor * toon;
+    float edge = abs(dot(normalize(vNormal), normalize(vViewDir)));
+    if (edge < uEdgeThreshold) {
+      base = vec3(0.0, 0.0, 0.0);
+    }
+    gl_FragColor = vec4(base, 1.0);
+  }
+`
+
 const CartoonMaterial = shaderMaterial(
   {
     uColor: new Color(0xffffff),
     uLightDir: new Vector3(1, 1, 1),
     uEdgeThreshold: 0.2
   },
-  `varying vec3 vNormal;\nvarying vec3 vViewDir;\n\nvoid main() {\n  vNormal = normalize(normalMatrix * normal);\n  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);\n  vViewDir = -mvPosition.xyz;\n  gl_Position = projectionMatrix * mvPosition;\n}`,
-  `uniform vec3 uColor;\nuniform vec3 uLightDir;\nuniform float uEdgeThreshold;\n\nvarying vec3 vNormal;\nvarying vec3 vViewDir;\n\nvoid main() {\n  vec3 lightDir = normalize(uLightDir);\n  float diffuse = max(dot(vNormal, lightDir), 0.0);\n  float levels = 3.0;\n  float toon = floor(diffuse * levels) / levels;\n  vec3 base = uColor * toon;\n  float edge = abs(dot(normalize(vNormal), normalize(vViewDir)));\n  if (edge < uEdgeThreshold) {\n    base = vec3(0.0, 0.0, 0.0);\n  }\n  gl_FragColor = vec4(base, 1.0);\n}`
+  vertexShader,
+  fragmentShader
 )
 
 export default CartoonMaterial

--- a/apps/web/app/CartoonShaderMaterial.ts
+++ b/apps/web/app/CartoonShaderMaterial.ts
@@ -1,0 +1,14 @@
+import { shaderMaterial } from '@react-three/drei'
+import { Color, Vector3 } from 'three'
+
+const CartoonMaterial = shaderMaterial(
+  {
+    uColor: new Color(0xffffff),
+    uLightDir: new Vector3(1, 1, 1),
+    uEdgeThreshold: 0.2
+  },
+  `varying vec3 vNormal;\nvarying vec3 vViewDir;\n\nvoid main() {\n  vNormal = normalize(normalMatrix * normal);\n  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);\n  vViewDir = -mvPosition.xyz;\n  gl_Position = projectionMatrix * mvPosition;\n}`,
+  `uniform vec3 uColor;\nuniform vec3 uLightDir;\nuniform float uEdgeThreshold;\n\nvarying vec3 vNormal;\nvarying vec3 vViewDir;\n\nvoid main() {\n  vec3 lightDir = normalize(uLightDir);\n  float diffuse = max(dot(vNormal, lightDir), 0.0);\n  float levels = 3.0;\n  float toon = floor(diffuse * levels) / levels;\n  vec3 base = uColor * toon;\n  float edge = abs(dot(normalize(vNormal), normalize(vViewDir)));\n  if (edge < uEdgeThreshold) {\n    base = vec3(0.0, 0.0, 0.0);\n  }\n  gl_FragColor = vec4(base, 1.0);\n}`
+)
+
+export default CartoonMaterial

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,11 +1,13 @@
 'use client'
 import { Canvas } from '@react-three/fiber'
 import SpinningBox from './SpinningBox'
+import CartoonModel from './CartoonModel'
 
 const Home = () => {
   return (
     <main style={{ height: '100vh', width: '100%' }}>
       <Canvas>
+        <CartoonModel url='/3d-models/rover/rover-body.glb' scale={1.5} />
         <SpinningBox />
       </Canvas>
     </main>


### PR DESCRIPTION
## Summary
- create cartoon shader material for use with React Three Fiber
- add `CartoonModel` wrapper around `GlbModel`
- render a GLB model with the cartoon shader on the homepage
- test cartoon model rendering

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_688163dbac4083208872f904c0bd10aa