### PR TITLE
Add packages alias

### DIFF
--- a/apps/web/app/promos/perseverance/page.tsx
+++ b/apps/web/app/promos/perseverance/page.tsx
@@ -3,7 +3,7 @@ import { Stars } from '@react-three/drei/core/Stars'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { Canvas } from '@react-three/fiber'
 import { Suspense } from 'react'
-import GlbModel from '@geocaching/glb-model'
+import GlbModel from '@/packages/glb-model/src'
 import { Sky } from '@react-three/drei/core/Sky'
 
 export const dynamic = 'force-static'

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -23,6 +23,7 @@
       "@/*": ["./*"],
       "@/app/*": ["./app/*"],
       "@/promos/*": ["./app/promos/*"],
+      "@/packages/*": ["../../packages/*"],
       "@geocaching/glb-model": ["../../packages/glb-model/src"]
     }
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'jest'
 
 const config: Config = {
   moduleNameMapper: {
+    '^@/packages/(.*)$': '<rootDir>/packages/$1',
     '^@/(.*)$': '<rootDir>/apps/web/$1',
     '^@/app/(.*)$': '<rootDir>/apps/web/app/$1',
     '^@geocaching/glb-model$': '<rootDir>/packages/glb-model/src'


### PR DESCRIPTION
## Summary
- add new `@/packages` alias
- use new alias on Perseverance promo page
- update Jest config for new alias

## Testing
- `bun run lint`
- `bun x tsc -p apps/web/tsconfig.json --noEmit`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_b_6883b860c6a08320ae8688d41394b7a1